### PR TITLE
Fix error message not working

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -74,8 +74,7 @@ var ColorInput = function (_React$Component) {
       var _props = this.props,
           label = _props.label,
           source = _props.source,
-          touched = _props.touched,
-          error = _props.error,
+          meta = _props.meta,
           elStyle = _props.elStyle,
           options = _props.options,
           picker = _props.picker,
@@ -90,7 +89,7 @@ var ColorInput = function (_React$Component) {
         _react2.default.createElement(_TextField2.default, _extends({}, input, {
           onFocus: this.handleOpen,
           floatingLabelText: label || _inflection2.default.humanize(source),
-          errorText: touched && error,
+          errorText: meta.touched && meta.error,
           style: elStyle
         })),
         this.state.show ? _react2.default.createElement(
@@ -120,6 +119,10 @@ ColorInput.propTypes = {
   options: _propTypes2.default.object,
   source: _propTypes2.default.string,
   input: _propTypes2.default.object,
+  meta: _propTypes2.default.shape({
+    touched: _propTypes2.default.bool,
+    error: _propTypes2.default.string
+  }),
   picker: function picker(props, propName, componentName) {
     return !ReactColor[props[propName] + 'Picker'] && new Error('Invalid prop `' + propName + '` supplied to `' + componentName + '`.');
   }

--- a/src/index.js
+++ b/src/index.js
@@ -22,8 +22,7 @@ class ColorInput extends React.Component {
     const {
       label,
       source,
-      touched,
-      error,
+      meta,
       elStyle,
       options,
       picker,
@@ -38,7 +37,7 @@ class ColorInput extends React.Component {
           {...input}
           onFocus={this.handleOpen}
           floatingLabelText={ label || inflection.humanize(source) }
-          errorText={touched && error}
+          errorText={meta.touched && meta.error}
           style={elStyle}
         />
         {
@@ -67,6 +66,10 @@ ColorInput.propTypes = {
   options: PropTypes.object,
   source: PropTypes.string,
   input: PropTypes.object,
+  meta: PropTypes.shape({
+    touched: PropTypes.bool,
+    error: PropTypes.string,
+  }),
   picker: (props, propName, componentName) =>
     !ReactColor[`${props[propName]}Picker`] &&
     new Error(`Invalid prop \`${propName}\` supplied to \`${componentName}\`.`)


### PR DESCRIPTION
The `touched` and `error` props should be a part of the `meta` prop for the error message to be correctly displayed.